### PR TITLE
Major API changes, better documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.0] - 2023-12-06
+
+- Major overhaul of the interface to use more-explicit and less-confusing method names
+- Remove code that tried to "version" collections and configsets, since it was dumb
+- Get github actions working to run tests
+- Make aliases even more of a paper-thin wrapper around collections, such that, e.g.
+  `coll = get_collection(alias_name)` will return the appropriate alias. Use
+  `coll.alias?` to determine if it's an alias or collection if that becomes important.
+
 ## [0.2.0] - 2023-12-01
 
 - Added options `:date` and `:datetime` to the `version:` argument to `create_collection`

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ cars_v1.delete!
 
 ```
 
+## Documentation
+
+Run `bundle exec rake docs` to generate the documentation in `docs/`
+
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,19 @@ RSpec::Core::RakeTask.new(:spec)
 
 require "standard/rake"
 
-task default: %i[spec standard]
+task default: %i[spec standard docs]
+task docs: %i[yard]
+
+require 'yard'
+
+YARD::Rake::YardocTask.new do |t|
+  t.files = ["lib/**/*.rb"] # optional
+  t.options = [
+    "-mmarkdown",
+    "--embed-mixin", "SolrCloud::Connection::CollectionAdmin",
+    "--embed-mixin", "SolrCloud::Connection::ConfigsetAdmin",
+    "--embed-mixin", "SolrCloud::Connection::AliasAdmin",
+    "--hide-void-return"
+  ]
+  # t.stats_options = ["--list-undoc"] # optional
+end

--- a/lib/solr_cloud/alias.rb
+++ b/lib/solr_cloud/alias.rb
@@ -9,7 +9,7 @@ module SolrCloud
   # Collection#alias_as
   class Alias < Collection
     # An alias is, shockingly, an alias. Convenience to differentiate aliases from collections.
-    # @see SolrCloud::Connection#alias?
+    # @see SolrCloud::Connection#get_alias?
     def alias?
       true
     end
@@ -32,25 +32,27 @@ module SolrCloud
     # for this might be added at some point
     # @return [Collection]
     def collection
-      connection.collection_for_alias(name)
+      connection.alias_map[name].collection
     end
 
     # Redefine what collection this alias points to
     # This is equivalent to dropping/re-adding the alias, or calling connection.create_alias with `force: true`
     # @param coll [String, Collection] either the name of the collection, or a collection object itself
     # @return [Collection] the now-current collection
-    def collection=(coll)
+    def switch_collection_to(coll)
       collect_name = case coll
                        when String
                          coll
                        when Collection
                          coll.name
                        else
-                         raise "Alias#collection= only takes a name(string) or a collection, not '#{coll}'"
+                         raise "Alias#switch_collection_to only takes a name(string) or a collection, not '#{coll}'"
                      end
-      raise NoSuchCollectionError unless connection.collection?(collect_name)
+      raise NoSuchCollectionError unless connection.has_collection?(collect_name)
       connection.create_alias(name: name, collection_name: collect_name, force: true)
     end
+
+    alias_method :collection=, :switch_collection_to
 
     # Get basic information on the underlying collection, so inherited methods that
     # use it (e.g., #healthy?) will work.

--- a/lib/solr_cloud/alias.rb
+++ b/lib/solr_cloud/alias.rb
@@ -2,7 +2,7 @@
 
 module SolrCloud
   # An alias can mostly be just treated as a collection. It will identify itself as an alias if you
-  # call #alias, and it can return and change the underlying collection it points to.
+  # call #alias?, and it can return and change the underlying collection it points to.
 
   # An alias shouldn't be created directly. Rather, get an existing one with
   # Connection#alias, or from a collection, or create one with

--- a/lib/solr_cloud/configset.rb
+++ b/lib/solr_cloud/configset.rb
@@ -7,7 +7,12 @@ module SolrCloud
   # throw an error if that's an illegal operation (because a collection is
   # using it)
   class Configset
-    attr_reader :name, :connection
+
+    # @return [String] the name of this configset
+    attr_reader :name
+
+    # @return [Connection] the connection object used to build this configset object
+    attr_reader :connection
 
     def initialize(name:, connection:)
       @name = name
@@ -18,8 +23,20 @@ module SolrCloud
     # @see Connection#delete_configset
     # @return The underlying connection
     def delete!
-      @connection.delete_configset(name)
-      @connection
+      connection.delete_configset(name)
+      connection
+    end
+
+    # Which collections use this configset?
+    # @return [Array<Collection>] The collections defined to use this configset
+    def used_by
+      connection.only_collections.select { |coll| coll.configset.name == name }
+    end
+
+    # Are there any collections currently using this configset?
+    # @return [Boolean]
+    def in_use?
+      !used_by.empty?
     end
 
     def inspect

--- a/lib/solr_cloud/connection.rb
+++ b/lib/solr_cloud/connection.rb
@@ -65,7 +65,7 @@ module SolrCloud
     # @param user [String] username for basic auth, if you're using it
     # @param password [String] password for basic auth, if you're using it
     # @param logger [#info, :off, nil] An existing logger to pass in. The symbol ":off" means
-    # don't do logging. If left undefined, will create a standard ruby logger to $stdout
+    #   don't do logging. If left undefined, will create a standard ruby logger to $stdout
     # @param adapter [Symbol] The underlying http library to use within Faraday
     def initialize(url:, user: nil, password: nil, logger: nil, adapter: :httpx)
       @url = url

--- a/lib/solr_cloud/connection/alias_admin.rb
+++ b/lib/solr_cloud/connection/alias_admin.rb
@@ -8,7 +8,7 @@ module SolrCloud
       AliasCollectionPair = Struct.new(:alias, :collection)
 
       # Create an alias for the given collection name
-      # @todo allow an alias to point to more than one collection?
+      # @todo allow an alias to point to more than one has_collection?
       # @param name [String] Name of the new alias
       # @param collection_name [String] name of the collection
       # @param force [Boolean] whether to overwrite an existing alias
@@ -18,24 +18,24 @@ module SolrCloud
         unless legal_solr_name?(name)
           raise IllegalNameError.new("'#{name}' is not a valid solr alias name. Use only ASCII letters/numbers, dash, and underscore")
         end
-        raise NoSuchCollectionError.new("Can't find collection #{collection_name}") unless collection?(collection_name)
-        if alias?(name) && !force
-          raise WontOverwriteError.new("Alias '#{name}' already points to collection '#{self.alias(name).collection.name}'; won't overwrite without force: true")
+        raise NoSuchCollectionError.new("Can't find collection #{collection_name}") unless has_collection?(collection_name)
+        if has_alias?(name) && !force
+          raise WontOverwriteError.new("Alias '#{name}' already points to collection '#{self.get_alias(name).collection.name}'; won't overwrite without force: true")
         end
         connection.get("solr/admin/collections", action: "CREATEALIAS", name: name, collections: collection_name)
-        self.alias(name)
+        get_alias(name)
       end
 
       # Is there an alias with this name?
       # @return [Boolean]
-      def alias?(name)
+      def has_alias?(name)
         alias_names.include? name
       end
 
       # List of alias objects
       # @return [Array<SolrCloud::Alias>] List of aliases
       def aliases
-        alias_map.values
+        alias_map.values.map(&:alias)
       end
 
       # List of alias names
@@ -44,28 +44,30 @@ module SolrCloud
         alias_map.keys
       end
 
-      # Get an alias object for the given name
+      # Get an alias object for the given name, erroring out if not found
+      # @param name [String] the name of the existing alias
+      # @return [Alias, nil] The alias if found, otherwise nil
+      def get_alias(name)
+        return nil unless has_alias?(name)
+        alias_map[name].alias
+      end
+
+      # Get an alias object for the given name, erroring out if not found
       # @param name [String] the name of the existing alias
       # @raise [SolrCloud::NoSuchAliasError] if it doesn't exist
       # @return [SolrCloud::Alias]
-      def alias(name)
-        am = alias_map
-        raise NoSuchAliasError unless am[name]
-        am[name]
-      end
-
-      # Get the collection associated with an alias
-      # @param name [String] alias name
-      # @return [Collection] collection associated with the alias
-      def collection_for_alias(name)
-        Collection.new(name: raw_alias_map[name], connection: self)
+      def get_alias!(name)
+        raise NoSuchAliasError unless has_alias?(name)
+        get_alias(name)
       end
 
       # Get the aliases and create a map of the form AliasName -> AliasObject
       # @return [Hash<String,Alias>] A hash mapping alias names to alias objects
       def alias_map
         raw_alias_map.keys.each_with_object({}) do |alias_name, h|
-          h[alias_name] = SolrCloud::Alias.new(name: alias_name, connection: self)
+          a = Alias.new(name: alias_name, connection: self)
+          c = Collection.new(name: raw_alias_map[alias_name], connection: self)
+          h[alias_name] = AliasCollectionPair.new(a, c)
         end
       end
 
@@ -77,3 +79,5 @@ module SolrCloud
     end
   end
 end
+
+

--- a/lib/solr_cloud/connection/alias_admin.rb
+++ b/lib/solr_cloud/connection/alias_admin.rb
@@ -5,10 +5,14 @@ module SolrCloud
     # methods having to do with aliases, to be included by the connection object.
     # These are split out only to make it easier to deal with them.
     module AliasAdmin
+
+      # A simple data-class to pair an alias with its collection
       AliasCollectionPair = Struct.new(:alias, :collection)
 
-      # Create an alias for the given collection name
-      # @todo allow an alias to point to more than one has_collection?
+      # Create an alias for the given collection name.
+      #
+      # In general, prefer {Collection#alias_as} instead of
+      # running everything through the connection object.
       # @param name [String] Name of the new alias
       # @param collection_name [String] name of the collection
       # @param force [Boolean] whether to overwrite an existing alias

--- a/lib/solr_cloud/connection/collection_admin.rb
+++ b/lib/solr_cloud/connection/collection_admin.rb
@@ -10,7 +10,7 @@ module SolrCloud
     # The idea is that you shouldn't need to know if something is an alias or a collection
     # until it's relevant
     module CollectionAdmin
-      # Create a new collection
+      # Create and return a new collection.
       # @param name [String] Name for the new collection
       # @param configset [String, Configset] (name of) the configset to use for this collection
       # @param shards [Integer]
@@ -32,7 +32,7 @@ module SolrCloud
                              configset.to_s
                          end
         raise WontOverwriteError.new("Collection #{name} already exists") if has_collection?(name)
-        raise NoSuchConfigSetError.new("Configset '#{configset_name}' doesn't exist") unless configset?(configset_name)
+        raise NoSuchConfigSetError.new("Configset '#{configset_name}' doesn't exist") unless has_configset?(configset_name)
 
         args = {
           :action => "CREATE",

--- a/lib/solr_cloud/connection/configset_admin.rb
+++ b/lib/solr_cloud/connection/configset_admin.rb
@@ -56,7 +56,7 @@ module SolrCloud
         end
         # TODO: Error check in here somewhere
         FileUtils.rm(zfile, force: true)
-        self.configset(name)
+        configset(name)
       end
 
       # Remove the configuration set with the given name. No-op if the

--- a/lib/solr_cloud/connection/configset_admin.rb
+++ b/lib/solr_cloud/connection/configset_admin.rb
@@ -28,7 +28,7 @@ module SolrCloud
       end
 
       # Get an existing configset
-      def configset(name)
+      def get_configset(name)
         Configset.new(name: name, connection: self)
       end
 
@@ -56,7 +56,7 @@ module SolrCloud
         end
         # TODO: Error check in here somewhere
         FileUtils.rm(zfile, force: true)
-        configset(name)
+        get_configset(name)
       end
 
       # Remove the configuration set with the given name. No-op if the

--- a/lib/solr_cloud/connection/configset_admin.rb
+++ b/lib/solr_cloud/connection/configset_admin.rb
@@ -7,30 +7,6 @@ module SolrCloud
     # methods having to do with configsets, to be included by the connection object.
     # These are split out only to make it easier to deal with them.
     module ConfigsetAdmin
-      # Get a list of the already-defined configSets
-      # @return [Array<Configset>] possibly empty list of configSets
-      def configsets
-        configset_names.map { |cs| Configset.new(name: cs, connection: self) }
-      end
-
-      # @return [Array<String>] the names of the config sets
-      def configset_names
-        connection.get("api/cluster/configs").body["configSets"]
-      end
-
-      alias_method :configurations, :configsets
-
-      # Check to see if a configset is defined
-      # @param name [String] Name of the configSet
-      # @return [Boolean] Whether a configset with that name exists
-      def configset?(name)
-        configset_names.include? name.to_s
-      end
-
-      # Get an existing configset
-      def get_configset(name)
-        Configset.new(name: name, connection: self)
-      end
 
       # Given the path to a solr configuration "conf" directory (i.e., the one with
       # solrconfig.xml in it), zip it up and send it to solr as a new configset.
@@ -45,7 +21,7 @@ module SolrCloud
           raise IllegalNameError.new("'#{config_set_name}' is not a valid solr configset name. Use only ASCII letters/numbers, dash, and underscore")
         end
 
-        if configset?(config_set_name) && !force
+        if has_configset?(config_set_name) && !force
           raise WontOverwriteError.new("Won't replace configset #{config_set_name} unless 'force: true' passed ")
         end
         zfile = "#{Dir.tmpdir}/solr_add_configset_#{name}_#{Time.now.hash}.zip"
@@ -59,13 +35,40 @@ module SolrCloud
         get_configset(name)
       end
 
+      # Get a list of the already-defined configSets
+      # @return [Array<Configset>] possibly empty list of configSets
+      def configsets
+        configset_names.map { |cs| Configset.new(name: cs, connection: self) }
+      end
+
+      # @return [Array<String>] the names of the config sets
+      def configset_names
+        connection.get("api/cluster/configs").body["configSets"]
+      end
+
+      # Check to see if a configset is defined
+      # @param name [String] Name of the configSet
+      # @return [Boolean] Whether a configset with that name exists
+      def has_configset?(name)
+        configset_names.include? name.to_s
+      end
+
+      # Get an existing configset
+      def get_configset(name)
+        Configset.new(name: name, connection: self)
+      end
+
       # Remove the configuration set with the given name. No-op if the
-      # configset doesn't actually exist. Use #configset? manually if you need to raise on does-not-exist
-      # @param [String,Symbol] name The name of the configuration set
+      # configset doesn't actually exist. Test with {#has_configset?} and
+      # {Configset#in_use?} manually if need be.
+      #
+      # In general, prefer using {Configset#delete!} instead of running everything
+      # through the connection object.
+      # @param [String] name The name of the configuration set
       # @raise [InUseError] if the configset can't be deleted because it's in use by a live collection
       # @return [Connection] self
       def delete_configset(name)
-        if configset? name
+        if has_configset? name
           connection.delete("api/cluster/configs/#{name}")
         end
         self
@@ -80,6 +83,8 @@ module SolrCloud
 
       # Pulled from the examples for rubyzip. No idea why it's not just a part
       # of the normal interface, but I guess I'm not one to judge.
+      #
+      # Code taken wholesale from https://github.com/rubyzip/rubyzip/blob/master/samples/example_recursive.rb
       class ZipFileGenerator
         # Initialize with the directory to zip and the location of the output archive.
         def initialize(input_dir, output_file)

--- a/lib/solr_cloud/connection/version.rb
+++ b/lib/solr_cloud/connection/version.rb
@@ -2,6 +2,6 @@
 
 module SolrCloud
   class Connection
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/solr_cloud-connection.gemspec
+++ b/solr_cloud-connection.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "yard"
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/spec/solr_cloud/alias_spec.rb
+++ b/spec/solr_cloud/alias_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe SolrCloud::Alias do
   before(:all) do
     cleanout!
-    @solr = connection
-    @config_name = @solr.create_configset(name: rnd_configname, confdir: test_conf_dir, force: true)
-    @collection = @solr.create_collection(name: rnd_collname, configset: @config_name)
+    @server = connection
+    @config_name = @server.create_configset(name: rnd_configname, confdir: test_conf_dir, force: true)
+    @collection = @server.create_collection(name: rnd_collname, configset: @config_name)
   end
 
   after(:all) do
@@ -12,63 +12,63 @@ RSpec.describe SolrCloud::Alias do
   end
 
   it "can create and delete an alias" do
-    a = @solr.create_alias(name: rnd_aliasname, collection_name: @collection.name)
-    expect(@solr.alias_names).to include(a.name)
+    a = @server.create_alias(name: rnd_aliasname, collection_name: @collection.name)
+    expect(@server.alias_names).to include(a.name)
     a.delete!
-    expect(@solr.alias_names).not_to include(a.name)
+    expect(@server.alias_names).not_to include(a.name)
   end
 
   it "identifies as an alias" do
-    a = @solr.create_alias(name: rnd_aliasname, collection_name: @collection.name)
+    a = @server.create_alias(name: rnd_aliasname, collection_name: @collection.name)
     expect(a.alias?)
     a.delete!
   end
 
   it "can be found as if it's a collection" do
     a = @collection.alias_as(rnd_aliasname)
-    expect(@solr.collection_names).to include(a.name)
+    expect(@server.collection_names).to include(a.name)
     a.delete!
   end
 
   it "can be gotten as if it's a collection" do
     a = @collection.alias_as(rnd_aliasname)
-    expect(@solr.get_collection(a.name)).to be_instance_of(SolrCloud::Alias)
+    expect(@server.get_collection(a.name)).to be_instance_of(SolrCloud::Alias)
     a.delete!
   end
 
   it "errors if the collection doesn't exist" do
-    expect { @solr.create_alias(name: rnd_aliasname, collection_name: "DOESNOTEXIST") }.to raise_error(SolrCloud::NoSuchCollectionError)
+    expect { @server.create_alias(name: rnd_aliasname, collection_name: "DOESNOTEXIST") }.to raise_error(SolrCloud::NoSuchCollectionError)
   end
 
   it "errors if you try to crate an alias that already exists without force: true" do
-    a = @solr.create_alias(name: rnd_aliasname, collection_name: @collection.name)
-    expect(@solr.alias_names).to include(a.name)
-    expect { @solr.create_alias(name: a.name, collection_name: @collection.name) }.to raise_error(SolrCloud::WontOverwriteError)
-    expect(@solr.create_alias(name: a.name, collection_name: @collection.name, force: true).name).to eq(a.name)
+    a = @server.create_alias(name: rnd_aliasname, collection_name: @collection.name)
+    expect(@server.alias_names).to include(a.name)
+    expect { @server.create_alias(name: a.name, collection_name: @collection.name) }.to raise_error(SolrCloud::WontOverwriteError)
+    expect(@server.create_alias(name: a.name, collection_name: @collection.name, force: true).name).to eq(a.name)
     a.delete!
   end
 
   it "throws an error if you try to create it with an illegal name" do
     expect {
-      @solr.create_alias(name: "abc!", collection_name: @collection.name)
+      @server.create_alias(name: "abc!", collection_name: @collection.name)
     }.to raise_error(SolrCloud::IllegalNameError)
   end
 
   it "can find its collection" do
-    a = @solr.create_alias(name: rnd_aliasname, collection_name: @collection.name)
+    a = @server.create_alias(name: rnd_aliasname, collection_name: @collection.name)
     expect(a.collection.name).to eq(@collection.name)
     a.delete!
   end
 
   it "returns nil if you try to get a non-existent alias" do
-    expect(@solr.get_alias("NOSUCHALIAS")).to be_nil
+    expect(@server.get_alias("NOSUCHALIAS")).to be_nil
   end
 
 
   it "can reset its collection with a collection object" do
-    a = @solr.create_alias(name: rnd_aliasname, collection_name: @collection.name)
+    a = @server.create_alias(name: rnd_aliasname, collection_name: @collection.name)
     expect(a.collection.name).to eq(@collection.name)
-    c2 = @solr.create_collection(name: rnd_collname, configset: @config_name)
+    c2 = @server.create_collection(name: rnd_collname, configset: @config_name)
     a.collection = c2
     expect(a.collection.name).to eq(c2.name)
     a.delete!
@@ -76,9 +76,9 @@ RSpec.describe SolrCloud::Alias do
   end
 
   it "can reset its collection with a collection name (string)" do
-    a = @solr.create_alias(name: rnd_aliasname, collection_name: @collection.name)
+    a = @server.create_alias(name: rnd_aliasname, collection_name: @collection.name)
     expect(a.collection.name).to eq(@collection.name)
-    c2 = @solr.create_collection(name: rnd_collname, configset: @config_name)
+    c2 = @server.create_collection(name: rnd_collname, configset: @config_name)
     a.collection = c2.name
     expect(a.collection.name).to eq(c2.name)
     a.delete!

--- a/spec/solr_cloud/alias_spec.rb
+++ b/spec/solr_cloud/alias_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe SolrCloud::Alias do
     a.delete!
   end
 
+  it "can be found as if it's a collection" do
+    a = @collection.alias_as(rnd_aliasname)
+    expect(@solr.collection_names).to include(a.name)
+    a2 = @solr.collection(a.name)
+    expect(a2.alias?)
+    expect(a.collection.name).to eq(@collection.name)
+    expect(a2.name).to eq(a.name)
+    expect(a2.collection.name).to eq(a.collection.name)
+    a.delete!
+    a2.delete!
+  end
+
   it "errors if the collection doesn't exist" do
     expect { @solr.create_alias(name: rnd_aliasname, collection_name: "DOESNOTEXIST") }.to raise_error(SolrCloud::NoSuchCollectionError)
   end

--- a/spec/solr_cloud/alias_spec.rb
+++ b/spec/solr_cloud/alias_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe SolrCloud::Alias do
   it "can be found as if it's a collection" do
     a = @collection.alias_as(rnd_aliasname)
     expect(@solr.collection_names).to include(a.name)
-    a2 = @solr.collection(a.name)
-    expect(a2.alias?)
-    expect(a.collection.name).to eq(@collection.name)
-    expect(a2.name).to eq(a.name)
-    expect(a2.collection.name).to eq(a.collection.name)
     a.delete!
-    a2.delete!
+  end
+
+  it "can be gotten as if it's a collection" do
+    a = @collection.alias_as(rnd_aliasname)
+    expect(@solr.get_collection(a.name)).to be_instance_of(SolrCloud::Alias)
+    a.delete!
   end
 
   it "errors if the collection doesn't exist" do
@@ -60,9 +60,10 @@ RSpec.describe SolrCloud::Alias do
     a.delete!
   end
 
-  it "errors out if you try to get a non-existent alias" do
-    expect { @solr.alias("NOSUCHALIAS") }.to raise_error(SolrCloud::NoSuchAliasError)
+  it "returns nil if you try to get a non-existent alias" do
+    expect(@solr.get_alias("NOSUCHALIAS")).to be_nil
   end
+
 
   it "can reset its collection with a collection object" do
     a = @solr.create_alias(name: rnd_aliasname, collection_name: @collection.name)

--- a/spec/solr_cloud/collection_spec.rb
+++ b/spec/solr_cloud/collection_spec.rb
@@ -2,17 +2,17 @@ RSpec.describe SolrCloud::Collection do
   before(:all) do
     verify_test_environment!
     @configname = rnd_configname
-    @solr = connection
+    @server = connection
   end
 
   describe "via connection object" do
     before(:all) do
       cleanout!
-      @solr.create_configset(name: @configname, confdir: test_conf_dir, force: true)
+      @server.create_configset(name: @configname, confdir: test_conf_dir, force: true)
     end
 
     after(:all) do
-      @solr.delete_configset(@configname)
+      @server.delete_configset(@configname)
     end
 
     before(:each) do
@@ -20,43 +20,48 @@ RSpec.describe SolrCloud::Collection do
     end
 
     after(:each) do
-      @solr.get_collection(@collection_name).delete! if @solr.has_collection?(@collection_name)
+      @server.get_collection(@collection_name).delete! if @server.has_collection?(@collection_name)
     end
 
     it "can create/delete a collection" do
-      coll = @solr.create_collection(name: @collection_name, configset: @configname)
-      expect(@solr.has_collection?(@collection_name))
+      coll = @server.create_collection(name: @collection_name, configset: @configname)
+      expect(@server.has_collection?(@collection_name))
       coll.delete!
-      expect(@solr.has_collection?(@collection_name)).to be_falsey
+      expect(@server.has_collection?(@collection_name)).to be_falsey
     end
 
     it "doesn't identify as an alias" do
-      coll = @solr.create_collection(name: @collection_name, configset: @configname)
+      coll = @server.create_collection(name: @collection_name, configset: @configname)
       expect(coll.alias?).to be_falsey
     end
 
     it "throws an error if you try to create a collection with a bad configset" do
       expect {
-        @solr.create_collection(name: @collection_name, configset: "INVALID")
+        @server.create_collection(name: @collection_name, configset: "INVALID")
       }.to raise_error(SolrCloud::NoSuchConfigSetError)
     end
 
     it "returns nil if you try to get a non-existant collection with get_collection" do
-      expect(@solr.get_collection("INVALID_COLLECTION_NAME")).to be_nil
+      expect(@server.get_collection("INVALID_COLLECTION_NAME")).to be_nil
     end
 
     it "returns an error if you try to get a non-existant collection with get_collection!" do
-      expect { @solr.get_collection!("INVALID_COLLECTION_NAME") }.to raise_error(SolrCloud::NoSuchCollectionError)
+      expect { @server.get_collection!("INVALID_COLLECTION_NAME") }.to raise_error(SolrCloud::NoSuchCollectionError)
+    end
+
+    it "can get its configset" do
+      coll = @server.create_collection(name: @collection_name, configset: @configname)
+      expect(coll.configset.name).to eq(@configname)
     end
 
     it "won't allow you to drop a configset in use" do
-      @solr.create_collection(name: @collection_name, configset: @configname)
-      expect { @solr.delete_configset @configname }.to raise_error(SolrCloud::ConfigSetInUseError)
+      @server.create_collection(name: @collection_name, configset: @configname)
+      expect { @server.delete_configset @configname }.to raise_error(SolrCloud::ConfigSetInUseError)
     end
 
     it "throws an error if you try to create it with an illegal name" do
       expect {
-        @solr.create_collection(name: "abc!", configset: @configname)
+        @server.create_collection(name: "abc!", configset: @configname)
       }.to raise_error(SolrCloud::IllegalNameError)
     end
   end
@@ -65,15 +70,15 @@ RSpec.describe SolrCloud::Collection do
     before(:all) do
       cleanout!
       @configname = rnd_configname
-      @solr = connection
-      @solr.create_configset(name: @configname, confdir: test_conf_dir, force: true)
+      @server = connection
+      @server.create_configset(name: @configname, confdir: test_conf_dir, force: true)
       @collection_name = rnd_collname
-      @collection = @solr.create_collection(name: @collection_name, configset: @configname)
+      @collection = @server.create_collection(name: @collection_name, configset: @configname)
     end
 
     after(:all) do
       @collection.delete!
-      @solr.delete_configset(@configname)
+      @server.delete_configset(@configname)
     end
 
     it "can check for aliveness" do
@@ -105,7 +110,7 @@ RSpec.describe SolrCloud::Collection do
     end
 
     it "doesn't return an alias that points to a different collection" do
-      other_collection = @solr.create_collection(name: rnd_collname, configset: @configname)
+      other_collection = @server.create_collection(name: rnd_collname, configset: @configname)
       a = other_collection.alias_as(rnd_aliasname)
       expect(@collection.get_alias(a.name)).to be_nil
       a.delete!
@@ -118,9 +123,9 @@ RSpec.describe SolrCloud::Collection do
     end
 
     it "can delete itself" do
-      coll = @solr.create_collection(name: rnd_collname, configset: @configname)
+      coll = @server.create_collection(name: rnd_collname, configset: @configname)
       coll.delete!
-      expect(@solr.collection_names).not_to include(coll.name)
+      expect(@server.collection_names).not_to include(coll.name)
       coll.delete!
     end
   end
@@ -128,22 +133,20 @@ RSpec.describe SolrCloud::Collection do
 
   describe "correctly forwards HTTP verbs" do
 
-    around(:all) do |ex|
-      @cs = connection.create_configset(name: rnd_configname, confdir: test_conf_dir, force: true)
-      ex.run
-      @cs.delete!
+    before(:all) do
+      @configset = connection.create_configset(name: rnd_configname, confdir: test_conf_dir, force: true)
     end
 
-    around(:example) do |ex|
-      @coll = connection.create_collection(name: rnd_collname, configset: @cs.name)
-      ex.run
-      @coll.delete!
+    after(:all) do
+      @configset.delete!
     end
 
     it "uploads and counts" do
-      expect(@coll.count).to be(0)
-      @coll.add({id: 1}).commit
-      expect(@coll.count).to be(1)
+      coll = connection.create_collection(name: rnd_collname, configset: @configset.name)
+      expect(coll.count).to be(0)
+      coll.add({id: 1}).commit
+      expect(coll.count).to be(1)
+      coll.delete!
     end
 
   end

--- a/spec/solr_cloud/configset_spec.rb
+++ b/spec/solr_cloud/configset_spec.rb
@@ -5,48 +5,71 @@ RSpec.describe SolrCloud::Configset do
   before(:all) do
     verify_test_environment!
     cleanout!
-    @solr = connection
+    @server = connection
     @configname = "config_tests" + Random.rand(999).to_s
     @collection_name = "collection_tests" + Random.rand(999).to_s
   end
 
   describe "config sets via the connection" do
     it "can get list of configsets" do
-      expect(@solr.configurations).to be_a(Array)
+      expect(@server.configsets).to be_a(Array)
     end
 
     it "can create/delete a configset" do
-      @solr.create_configset(name: @configname, confdir: test_conf_dir)
-      expect(@solr.configset_names).to include(@configname)
-      @solr.delete_configset(@configname)
-      expect(@solr.configset_names).not_to include(@configname)
+      @server.create_configset(name: @configname, confdir: test_conf_dir)
+      expect(@server.configset_names).to include(@configname)
+      @server.delete_configset(@configname)
+      expect(@server.configset_names).not_to include(@configname)
     end
 
     it "throws an error if you try to create it with an illegal name" do
       expect {
-        @solr.create_configset(name: "abc!", confdir: test_conf_dir)
+        @server.create_configset(name: "abc!", confdir: test_conf_dir)
       }.to raise_error(SolrCloud::IllegalNameError)
     end
 
     it "won't overwrite existing configset without force: true" do
-      @solr.create_configset(name: @configname, confdir: test_conf_dir)
-      expect { @solr.create_configset(name: @configname, confdir: test_conf_dir) }.to raise_error(SolrCloud::WontOverwriteError)
-      @solr.delete_configset(@configname)
+      @server.create_configset(name: @configname, confdir: test_conf_dir)
+      expect { @server.create_configset(name: @configname, confdir: test_conf_dir) }.to raise_error(SolrCloud::WontOverwriteError)
+      @server.delete_configset(@configname)
     end
 
     it "will overwrite existing configset by using force: true" do
-      @solr.create_configset(name: @configname, confdir: test_conf_dir)
-      expect { @solr.create_configset(name: @configname, confdir: test_conf_dir, force: true) }.not_to raise_error
-      @solr.delete_configset(@configname)
+      cset = @server.create_configset(name: @configname, confdir: test_conf_dir)
+      coll = @server.create_collection(name: rnd_collname, configset: cset.name)
+      expect { @server.create_configset(name: @configname, confdir: test_conf_dir, force: true) }.not_to raise_error
+      coll.delete!
+      cset.delete!
     end
   end
 
   describe "configset object" do
-    it "can delete itself" do
-      cset = @solr.create_configset(name: rnd_configname, confdir: test_conf_dir)
-      expect(@solr.configset_names).to include(cset.name)
-      cset.delete!
-      expect(@solr.configset_names).not_to include(cset.name)
+    before(:each) do
+      @cset = @server.create_configset(name: rnd_configname, confdir: test_conf_dir)
     end
+
+    after(:each) do
+      @cset.delete!
+    end
+
+    it "can delete itself" do
+      expect(@server.configset_names).to include(@cset.name)
+      @cset.delete!
+      expect(@server.configset_names).not_to include(@cset.name)
+    end
+
+    it "knows what collections use it" do
+      coll = @server.create_collection(name: rnd_collname, configset: @cset.name)
+      expect(@cset.used_by.map(&:name)).to include(coll.name)
+      coll.delete!
+    end
+
+    it "knows if it's in use" do
+      expect(@cset.in_use?).to be_falsey
+      coll = @server.create_collection(name: rnd_collname, configset: @cset.name)
+      expect(@cset.in_use?).to be_truthy
+      coll.delete!
+    end
+
   end
 end

--- a/spec/solr_cloud/connection_spec.rb
+++ b/spec/solr_cloud/connection_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SolrCloud::Connection do
   before(:all) do
     verify_test_environment!
     cleanout!
-    @solr = connection
+    @server = connection
     @configname = "config_tests" + Random.rand(999).to_s
     @collection_name = "collection_tests" + Random.rand(999).to_s
   end
@@ -50,14 +50,14 @@ RSpec.describe SolrCloud::Connection do
 
   describe "utility methods" do
     it "can detect legal/illegal names for solr collections/configsets/aliases" do
-      expect(@solr.legal_solr_name?("abc")).to be_truthy
-      expect(@solr.legal_solr_name?("abc-def")).to be_truthy
-      expect(@solr.legal_solr_name?("abc-123")).to be_truthy
-      expect(@solr.legal_solr_name?("abc_123")).to be_truthy
-      expect(@solr.legal_solr_name?("füdgüd")).to be_falsey
-      expect(@solr.legal_solr_name?("abc!123")).to be_falsey
-      expect(@solr.legal_solr_name?("abc|123")).to be_falsey
-      expect(@solr.legal_solr_name?("_abc")).to be_falsey
+      expect(@server.legal_solr_name?("abc")).to be_truthy
+      expect(@server.legal_solr_name?("abc-def")).to be_truthy
+      expect(@server.legal_solr_name?("abc-123")).to be_truthy
+      expect(@server.legal_solr_name?("abc_123")).to be_truthy
+      expect(@server.legal_solr_name?("füdgüd")).to be_falsey
+      expect(@server.legal_solr_name?("abc!123")).to be_falsey
+      expect(@server.legal_solr_name?("abc|123")).to be_falsey
+      expect(@server.legal_solr_name?("_abc")).to be_falsey
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ end
 # Clean out whatever's left over from the last run of failed tests. Need to do aliases then
 # collections then configsets due to possible dependencies.
 def cleanout!
-  connection.collections.select{|c| c.name.start_with?("rspec_alias")}.each(&:delete!)
+  connection.aliases.select{|c| c.name.start_with?("rspec_alias")}.each(&:delete!)
   connection.collections.select{|c| c.name.start_with?("rspec_collection")}.each(&:delete!)
   connection.configset_names.select { |x| x.start_with?("rspec_config_") }.each do |cs|
     connection.delete_configset(cs)


### PR DESCRIPTION
See the README for most of the new syntax. In general, change, e.g., `collection?(name)` to `has_collection?(name)` and
`coll = collection(name)` to `coll = get_collection(name)` because upon using the code I found it really hard to follow with so many similar method names.