### PR TITLE
fix: Solr 10 compatibility -- switch configset ops to v1 API, fix nil aliases

### DIFF
--- a/lib/solr_cloud/connection/alias_admin.rb
+++ b/lib/solr_cloud/connection/alias_admin.rb
@@ -77,7 +77,7 @@ module SolrCloud
       # The "raw" alias map, which just maps alias names to collection names
       # @return [Hash<String, String>]
       def raw_alias_map
-        connection.get("solr/admin/collections", action: "LISTALIASES").body["aliases"]
+        connection.get("solr/admin/collections", action: "LISTALIASES").body["aliases"] || {}
       end
     end
   end

--- a/lib/solr_cloud/connection/configset_admin.rb
+++ b/lib/solr_cloud/connection/configset_admin.rb
@@ -26,8 +26,9 @@ module SolrCloud
         zfile = "#{Dir.tmpdir}/solr_add_configset_#{name}_#{Time.now.hash}.zip"
         z = ZipFileGenerator.new(confdir, zfile)
         z.write
-        @connection.put("api/cluster/configs/#{config_set_name}") do |req|
+        @connection.post("solr/admin/configs?action=UPLOAD&name=#{config_set_name}") do |req|
           req.body = File.binread(zfile)
+          req.headers["Content-Type"] = "application/octet-stream"
         end
         # TODO: Error check in here somewhere
         FileUtils.rm(zfile, force: true)
@@ -42,7 +43,7 @@ module SolrCloud
 
       # @return [Array<String>] the names of the config sets
       def configset_names
-        connection.get("api/cluster/configs").body["configSets"]
+        connection.get("solr/admin/configs", action: "LIST").body["configSets"]
       end
 
       # Check to see if a configset is defined
@@ -68,7 +69,7 @@ module SolrCloud
       # @return [Connection] self
       def delete_configset(name)
         if has_configset? name
-          connection.delete("api/cluster/configs/#{name}")
+          connection.get("solr/admin/configs", action: "DELETE", name: name)
         end
         self
       rescue Faraday::BadRequestError => e


### PR DESCRIPTION
## Why

Solr 10 removed the v2 API path `api/cluster/configs` used for configset operations (LIST, UPLOAD, DELETE). Any call to these endpoints returns HTTP 404 with `"Cannot find API for the path: /cluster/configs"`, breaking all configset management at startup.

Additionally, `raw_alias_map` returns `nil` (not an empty hash) from Solr when no aliases exist, causing a `NoMethodError` on `.keys` in `alias_map`.

## What Changed

**`lib/solr_cloud/connection/configset_admin.rb`** — switch all three configset operations from the removed v2 `api/cluster/configs` path to the equivalent v1 API:

| Operation | Before | After |
|-----------|--------|-------|
| List | `GET api/cluster/configs` | `GET solr/admin/configs?action=LIST` |
| Upload | `PUT api/cluster/configs/{name}` (body = zip) | `POST solr/admin/configs?action=UPLOAD&name={name}` with `Content-Type: application/octet-stream` |
| Delete | `DELETE api/cluster/configs/{name}` | `GET solr/admin/configs?action=DELETE&name={name}` |

The v1 Configs API (`/solr/admin/configs`) remains fully supported in Solr 10.

**`lib/solr_cloud/connection/alias_admin.rb`** — add `|| {}` nil guard to `raw_alias_map` so that a Solr instance with no aliases defined does not raise `NoMethodError: undefined method 'keys' for nil`.

## Verification

Tested against Solr 10.0.0 in SolrCloud mode. Full indexing run (configset upload, collection creation, alias pointing, suggester rebuild) completed successfully after these changes.
